### PR TITLE
Trajectory preview

### DIFF
--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -208,11 +208,8 @@ class CuRoboTrajectoryMaker(Node):
         # Set joint names
         joint_trajectory_msg.joint_names = traj.joint_names
 
-        # Determine the number of points (assuming position list defines this)
-        num_points = len(traj.position)
-
-        # Create a list of JointTrajectoryPoints
-        for i in range(num_points):
+        # Create a list of JointTrajectoryPoints for every position in the JointState
+        for i in range(len(traj.position)):
             joint_trajectory_point = JointTrajectoryPoint()
 
             # Extract the i-th positions, velocities, and accelerations

--- a/docker/x86.dockerfile
+++ b/docker/x86.dockerfile
@@ -216,6 +216,12 @@ RUN sudo rosdep init # "sudo rosdep init --include-eol-distros" && \
     rosdep update # "sudo rosdep update --include-eol-distros" && \
     rosdep install -i --from-path src --rosdistro "$ROS_DISTRO" --skip-keys=librealsense2 -y
 
+# Setup for trajectory_preview
+RUN git clone https://github.com/swri-robotics/trajectory_preview.git
+WORKDIR /home/ros2_ws
+RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
+    colcon build"
+
 RUN source /opt/ros/"$ROS_DISTRO"/setup.bash && \
     cd /home/ros2_ws && \
     . install/local_setup.bash
@@ -223,7 +229,7 @@ RUN source /opt/ros/"$ROS_DISTRO"/setup.bash && \
 WORKDIR /home/ros2_ws
 
 # Fix missing "ucm_set_global_opts"
-RUN sudo apt-get update && sudo apt-get install --reinstall -y \
+RUN apt-get update && apt-get install --reinstall -y \
     hwloc-nox \
     libmpich-dev \
     libmpich12 \

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -1,15 +1,17 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, LogInfo
+from launch.actions import LogInfo
 from launch_ros.actions import Node
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from ament_index_python.packages import get_package_share_directory
 import os
 
+
 def generate_launch_description():
     # Déclaration du répertoire de lancement de curobo_ros
-    curobo_ros_launch_dir = os.path.join(get_package_share_directory('curobo_ros'), 'launch')
-    
+    curobo_ros_launch_dir = os.path.join(
+        get_package_share_directory('curobo_ros'), 'launch')
+
     return LaunchDescription([
         # Define the static transform publisher node
         Node(
@@ -17,7 +19,8 @@ def generate_launch_description():
             executable='static_transform_publisher',
             name='static_transform_publisher',
             output='screen',
-            arguments=['0.5', '0', '0.5', '0', '0', '0', 'base_0', 'camera_link']
+            arguments=['0.5', '0', '0.5', '0',
+                       '0', '0', 'base_0', 'camera_link']
         ),
 
         # Include the RViz2 launch file from curobo_ros
@@ -30,7 +33,8 @@ def generate_launch_description():
         # Include the RealSense camera launch file
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(get_package_share_directory('realsense2_camera'), 'launch', 'rs_launch.py')
+                os.path.join(get_package_share_directory(
+                    'realsense2_camera'), 'launch', 'rs_launch.py')
             ),
             launch_arguments={'clip_distance': '0.8'}.items()
         ),
@@ -42,7 +46,7 @@ def generate_launch_description():
             name='curobo_fk',
             output='screen'
         ),
-        
+
         # Run curobo_gen_traj node
         # Node(
         #     package='curobo_ros',
@@ -50,7 +54,7 @@ def generate_launch_description():
         #     name='curobo_gen_traj',
         #     output='screen'
         # ),
-        
+
         # Run curobo_int_mark node
         Node(
             package='curobo_ros',
@@ -58,7 +62,7 @@ def generate_launch_description():
             name='curobo_int_mark',
             output='screen'
         ),
-        
+
         # Log an informational message
         LogInfo(
             msg='All nodes and launch files are launched'

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -3,6 +3,9 @@ from launch.actions import LogInfo
 from launch_ros.actions import Node
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, PathJoinSubstitution
+from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
+from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
 import os
 
@@ -11,6 +14,14 @@ def generate_launch_description():
     # Déclaration du répertoire de lancement de curobo_ros
     curobo_ros_launch_dir = os.path.join(
         get_package_share_directory('curobo_ros'), 'launch')
+
+    trajectory_preview_launch_dir = os.path.join(
+        get_package_share_directory('trajectory_preview'), 'launch')
+
+    urdf_file_name = 'm1013.urdf'
+
+    urdf = Command(['cat ', PathJoinSubstitution(
+        [FindPackageShare('curobo_ros'), 'curobo_doosan/src/m1013/', urdf_file_name])])
 
     return LaunchDescription([
         # Define the static transform publisher node
@@ -61,6 +72,18 @@ def generate_launch_description():
             executable='curobo_int_mark',
             name='curobo_int_mark',
             output='screen'
+        ),
+
+        # Include the trajectory_preview launch file
+        IncludeLaunchDescription(
+            XMLLaunchDescriptionSource(
+                os.path.join(trajectory_preview_launch_dir,
+                             'robot_model_preview_pipeline.launch.xml')
+            ),
+            launch_arguments={
+                'robot_description': urdf,
+                'root_frame': 'base_0',
+            }.items(),
         ),
 
         # Log an informational message

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -15,9 +15,6 @@ def generate_launch_description():
     curobo_ros_launch_dir = os.path.join(
         get_package_share_directory('curobo_ros'), 'launch')
 
-    trajectory_preview_launch_dir = os.path.join(
-        get_package_share_directory('trajectory_preview'), 'launch')
-
     urdf_file_name = 'm1013.urdf'
 
     urdf = Command(['cat ', PathJoinSubstitution(
@@ -77,7 +74,7 @@ def generate_launch_description():
         # Include the trajectory_preview launch file
         IncludeLaunchDescription(
             XMLLaunchDescriptionSource(
-                os.path.join(trajectory_preview_launch_dir,
+                os.path.join(curobo_ros_launch_dir,
                              'robot_model_preview_pipeline.launch.xml')
             ),
             launch_arguments={

--- a/launch/robot_model_preview_pipeline.launch.xml
+++ b/launch/robot_model_preview_pipeline.launch.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0."?>
+<!-- This launch file comes from the trajectory_preview repository (https://github.com/swri-robotics/trajectory_preview)
+     The "preview_joint_states_topic" arg was changed to its correct topic in order to make the pipeline function -->
+<launch>
+  <arg name="robot_description" description="Robot description string" />
+  <arg name="root_frame" description="Root frame of the nominal TF tree, at which to connect the preview TF tree" />
+  <arg name="preview_joint_states_topic" default="/trajectory/joint_states"/>
+
+  <node pkg="joint_state_publisher" exec="joint_state_publisher" namespace="preview">
+    <param name="source_list" value="[$(var preview_joint_states_topic)]"/>
+  </node>
+
+  <node pkg="robot_state_publisher" exec="robot_state_publisher" namespace="preview">
+    <param name="robot_description" value="$(var robot_description)"/>
+    <param name="frame_prefix" value="preview/"/>
+  </node>
+
+  <node pkg="tf2_ros" exec="static_transform_publisher" args="0 0 0 0 0 0 $(var root_frame) preview/$(var root_frame)" namespace="preview"/>
+
+</launch>

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -28,6 +28,9 @@ Panels:
     Name: Time
     SyncMode: 0
     SyncSource: DepthCloud
+  - Class: trajectory_preview/TrajectoryPreviewPanel
+    Name: Trajectory Preview
+    Value: true
 Visualization Manager:
   Class: ""
   Displays:
@@ -90,18 +93,15 @@ Visualization Manager:
           base_0:
             camera_link:
               camera_color_frame:
-                camera_color_optical_frame:
-                  {}
+                camera_color_optical_frame: {}
               camera_depth_frame:
-                camera_depth_optical_frame:
-                  {}
+                camera_depth_optical_frame: {}
             link1:
               link2:
                 link3:
                   link4:
                     link5:
-                      link6:
-                        {}
+                      link6: {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -181,8 +181,7 @@ Visualization Manager:
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: MarkerArray
-      Namespaces:
-        {}
+      Namespaces: {}
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -232,8 +231,7 @@ Visualization Manager:
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: MarkerArray
-      Namespaces:
-        {}
+      Namespaces: {}
       Topic:
         Depth: 5
         Durability Policy: Volatile

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -7,7 +7,6 @@ Panels:
         - /Global Options1
         - /Status1
         - /DepthCloud1/Auto Size1
-        - /MarkerArray2
       Splitter Ratio: 0.5
     Tree Height: 545
   - Class: rviz_common/Selection
@@ -30,7 +29,6 @@ Panels:
     SyncSource: DepthCloud
   - Class: trajectory_preview/TrajectoryPreviewPanel
     Name: Trajectory Preview
-    Value: true
 Visualization Manager:
   Class: ""
   Displays:
@@ -81,6 +79,22 @@ Visualization Manager:
           Value: true
         link6:
           Value: true
+        preview/base_0:
+          Value: true
+        preview/link1:
+          Value: true
+        preview/link2:
+          Value: true
+        preview/link3:
+          Value: true
+        preview/link4:
+          Value: true
+        preview/link5:
+          Value: true
+        preview/link6:
+          Value: true
+        preview/world:
+          Value: true
         world:
           Value: true
       Marker Scale: 1
@@ -102,6 +116,13 @@ Visualization Manager:
                   link4:
                     link5:
                       link6: {}
+            preview/base_0:
+              preview/link1:
+                preview/link2:
+                  preview/link3:
+                    preview/link4:
+                      preview/link5:
+                        preview/link6: {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -181,7 +202,8 @@ Visualization Manager:
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: MarkerArray
-      Namespaces: {}
+      Namespaces:
+        trajectory: true
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -239,6 +261,71 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /visualization_marker_voxel
       Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /preview/robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: /preview
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -317,6 +404,8 @@ Window Geometry:
   Time:
     collapsed: false
   Tool Properties:
+    collapsed: false
+  Trajectory Preview:
     collapsed: false
   Views:
     collapsed: true


### PR DESCRIPTION
Add [trajectory preview](https://github.com/swri-robotics/trajectory_preview) to the project.
Required:

- Publishing the trajectory from the `curobo_test` node. Also made it possible to run without a depth input.
- Adding a launch file to correct a subscription topic for the preview.
- Adding the necessary parts to the RViz config file.
- Adding the source repo to the `dockerfile`.