### PR TITLE
Add trajectory preview and start trajectory parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ros2 run curobo_ros curobo_gen_traj
 Pour utiliser Rviz2 afin de visualiser le robot ou toute autre chose, veuillez exécuter la commande suivante :
 
 ```bash
-ros2 launch curobo_ros launch_rviz2.launch.py
+ros2 launch curobo_ros gen_traj.launch.py
 ```
 
 Ce fichier de lancement est configurable a votre souhait.

--- a/README.md
+++ b/README.md
@@ -133,3 +133,24 @@ sudo apt-get update && sudo apt-get install --reinstall -y \
   libmpich-dev \
   hwloc-nox libmpich12 mpich
 ```
+
+### Problèmes exclusifs à Windows
+
+#### Incapacité de lancer les conteneurs
+
+Dépendamment de la configuration du matériel, Docker pourrait ne pas fonctionner du tout dû à une absence de mémoire virtuelle. Pour régler cela, il suffit d'activer l'option de `virtualisation` du CPU dans votre BIOS. Le nom exacte de l'option et la méthode pour effectuer le changement variera d'un ordinateur à l'autre.
+
+#### Incapacité de lancer de fenêtres à partir du Docker sur Windows
+
+Le projet nécessite un `Xserver` pour lancer des fenêtres à partir du Docker sur l'ordinateur local. Une solution sous Windows est l'utilisation de [XLaunch](https://x.cygwin.com/docs/xlaunch/) disponible [ici](https://sourceforge.net/projects/vcxsrv/).
+
+Préalablement au lancement initial du script `start_docker_x86.sh`, il faut:
+
+- Lancer XLaunch. Choissisez les options par défaut, sauf pour la case `Disable access control` qu'il faut cocher.
+- Dans le terminal que vous utiliserez pour lancer le script, effectuez:
+
+  ```bash
+  export DISPLAY=<adresse_IP>:0
+  ```
+
+  Votre adresse IP locale peut être trouvé grâce à la commande `ipconfig`

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -36,9 +36,6 @@ class CuRoboTrajectoryMaker(Node):
         self.declare_parameter('timeout', 5.0)
         self.declare_parameter('time_dilation_factor', 0.5)
 
-        initial_voxel_size = 0.02
-        self.declare_parameter('voxel_size', initial_voxel_size)
-
         self.default_config = None
         self.j_names = None
         self.robot_cfg = None
@@ -47,6 +44,7 @@ class CuRoboTrajectoryMaker(Node):
         self.depth_image = None
         self.marker_data = None
         self.depth = 0
+        self.voxel_size = 0.02
 
         self.marker_publisher = MarkerPublisher()
         self.trajectory_publisher = self.create_publisher(
@@ -66,7 +64,7 @@ class CuRoboTrajectoryMaker(Node):
                     "world": {
                         "pose": [0, 0, 0, 1, 0, 0, 0],
                         "integrator_type": "occupancy",
-                        "voxel_size":  initial_voxel_size,
+                        "voxel_size":  self.voxel_size,
                     },
                 },
             }
@@ -240,15 +238,12 @@ class CuRoboTrajectoryMaker(Node):
         # Voxel debug
         bounding = Cuboid("t", dims=[1, 1, 1.0], pose=[1, 0, 0.5, 1, 0, 0, 0])
 
-        voxel_size = self.get_parameter(
-            'voxel_size').get_parameter_value().double_value
-
         voxels = self.world_model.get_voxels_in_bounding_box(
-            bounding, voxel_size)
+            bounding, self.voxel_size)
         # print(len(voxels))
         if voxels.shape[0] > 0:
             voxels = voxels.cpu().numpy()
-        self.marker_publisher.publish_markers_voxel(voxels, voxel_size)
+        self.marker_publisher.publish_markers_voxel(voxels, self.voxel_size)
 
     def trajectory_generator(self):
         if not self.marker_received:

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -118,7 +118,7 @@ class CuRoboTrajectoryMaker(Node):
 
         #### CAMERA INFO ####
         self.success, camera_info_sub = wait_for_message(
-            CameraInfo, self, '/camera/camera/depth/camera_info', 10)
+            CameraInfo, self, '/camera/camera/depth/camera_info', 1)
         if self.success:
             self.intrinsics = torch.tensor(
                 camera_info_sub.k).view(3, 3).float()

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -208,11 +208,8 @@ class CuRoboTrajectoryMaker(Node):
         # Set joint names
         joint_trajectory_msg.joint_names = traj.joint_names
 
-        # Determine the number of points (assuming position list defines this)
-        num_points = len(traj.position)
-
-        # Create a list of JointTrajectoryPoints
-        for i in range(num_points):
+        # Create a list of JointTrajectoryPoints for every position in the JointState
+        for i in range(len(traj.position)):
             joint_trajectory_point = JointTrajectoryPoint()
 
             # Extract the i-th positions, velocities, and accelerations

--- a/docker/start_docker_x86.sh
+++ b/docker/start_docker_x86.sh
@@ -10,19 +10,35 @@
 ## its affiliates is strictly prohibited.
 ##
 
-# Assurez-vous que le serveur X11 autorise les connexions depuis Docker
-xhost +local:docker
+if ! [[ "$OSTYPE" == "msys" ]]; then
+    # Assurez-vous que le serveur X11 autorise les connexions depuis Docker
+    xhost +local:docker
 
-# Exécutez le conteneur Docker avec les bonnes options
-docker run --name x86docker --rm -it \
-    --privileged \
-    -e NVIDIA_DISABLE_REQUIRE=1 \
-    -e NVIDIA_DRIVER_CAPABILITIES=all \
-    --device=/dev/:/dev/ \
-    --hostname ros1-docker \
-    --add-host ros1-docker:127.0.0.1 \
-    --gpus all \
-    --network host \
-    -e DISPLAY=$DISPLAY \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    curobo_docker:x86
+    # Exécutez le conteneur Docker avec les bonnes options
+    docker run --name x86docker --rm -it \
+        --privileged \
+        -e NVIDIA_DISABLE_REQUIRE=1 \
+        -e NVIDIA_DRIVER_CAPABILITIES=all \
+        --device=/dev/:/dev/ \
+        --hostname ros1-docker \
+        --add-host ros1-docker:127.0.0.1 \
+        --gpus all \
+        --network host \
+        -e DISPLAY=$DISPLAY \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        curobo_docker:x86
+else
+    echo "Detected OS is msys, make sure to have an X server running on your host machine"
+    # Exécutez seulement le conteneur Docker avec les options appropriées
+    docker run --name x86docker --rm -it \
+        --privileged \
+        -e NVIDIA_DISABLE_REQUIRE=1 \
+        -e NVIDIA_DRIVER_CAPABILITIES=all \
+        --hostname ros1-docker \
+        --add-host ros1-docker:127.0.0.1 \
+        --gpus all \
+        --network host \
+        -e DISPLAY=$DISPLAY \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        curobo_docker:x86
+fi

--- a/docker/x86.dockerfile
+++ b/docker/x86.dockerfile
@@ -216,6 +216,12 @@ RUN sudo rosdep init # "sudo rosdep init --include-eol-distros" && \
     rosdep update # "sudo rosdep update --include-eol-distros" && \
     rosdep install -i --from-path src --rosdistro "$ROS_DISTRO" --skip-keys=librealsense2 -y
 
+# Setup for trajectory_preview
+RUN git clone https://github.com/swri-robotics/trajectory_preview.git
+WORKDIR /home/ros2_ws
+RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
+    colcon build"
+
 RUN source /opt/ros/"$ROS_DISTRO"/setup.bash && \
     cd /home/ros2_ws && \
     . install/local_setup.bash
@@ -223,7 +229,7 @@ RUN source /opt/ros/"$ROS_DISTRO"/setup.bash && \
 WORKDIR /home/ros2_ws
 
 # Fix missing "ucm_set_global_opts"
-RUN sudo apt-get update && sudo apt-get install --reinstall -y \
+RUN apt-get update && apt-get install --reinstall -y \
     hwloc-nox \
     libmpich-dev \
     libmpich12 \

--- a/docker/x86.dockerfile
+++ b/docker/x86.dockerfile
@@ -140,12 +140,6 @@ RUN python -m pip install "robometrics[evaluator] @ git+https://github.com/fishb
 
 RUN export LD_LIBRARY_PATH="/opt/hpcx/ucx/lib:$LD_LIBRARY_PATH"
 
-ADD https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64 /tmp/code_latest_amd64.deb
-RUN sudo dpkg -i /tmp/code_latest_amd64.deb
-
-#alias for code:
-
-RUN echo "alias code='code --user-data-dir=./vscode --no-sandbox'" >> /root/.bashrc
 ADD http://archive.ubuntu.com/ubuntu/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.25-1ubuntu2_amd64.deb /tmp/libusb-1.0-0_1.0.25-1ubuntu2_amd64.deb
 RUN dpkg -i /tmp/libusb-1.0-0_1.0.25-1ubuntu2_amd64.deb
 

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -1,15 +1,17 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, LogInfo
+from launch.actions import LogInfo
 from launch_ros.actions import Node
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from ament_index_python.packages import get_package_share_directory
 import os
 
+
 def generate_launch_description():
     # Déclaration du répertoire de lancement de curobo_ros
-    curobo_ros_launch_dir = os.path.join(get_package_share_directory('curobo_ros'), 'launch')
-    
+    curobo_ros_launch_dir = os.path.join(
+        get_package_share_directory('curobo_ros'), 'launch')
+
     return LaunchDescription([
         # Define the static transform publisher node
         Node(
@@ -17,7 +19,8 @@ def generate_launch_description():
             executable='static_transform_publisher',
             name='static_transform_publisher',
             output='screen',
-            arguments=['0.5', '0', '0.5', '0', '0', '0', 'base_0', 'camera_link']
+            arguments=['0.5', '0', '0.5', '0',
+                       '0', '0', 'base_0', 'camera_link']
         ),
 
         # Include the RViz2 launch file from curobo_ros
@@ -30,7 +33,8 @@ def generate_launch_description():
         # Include the RealSense camera launch file
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
-                os.path.join(get_package_share_directory('realsense2_camera'), 'launch', 'rs_launch.py')
+                os.path.join(get_package_share_directory(
+                    'realsense2_camera'), 'launch', 'rs_launch.py')
             ),
             launch_arguments={'clip_distance': '0.8'}.items()
         ),
@@ -42,7 +46,7 @@ def generate_launch_description():
             name='curobo_fk',
             output='screen'
         ),
-        
+
         # Run curobo_gen_traj node
         # Node(
         #     package='curobo_ros',
@@ -50,7 +54,7 @@ def generate_launch_description():
         #     name='curobo_gen_traj',
         #     output='screen'
         # ),
-        
+
         # Run curobo_int_mark node
         Node(
             package='curobo_ros',
@@ -58,7 +62,7 @@ def generate_launch_description():
             name='curobo_int_mark',
             output='screen'
         ),
-        
+
         # Log an informational message
         LogInfo(
             msg='All nodes and launch files are launched'

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -3,6 +3,9 @@ from launch.actions import LogInfo
 from launch_ros.actions import Node
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import Command, PathJoinSubstitution
+from launch_xml.launch_description_sources import XMLLaunchDescriptionSource
+from launch_ros.substitutions import FindPackageShare
 from ament_index_python.packages import get_package_share_directory
 import os
 
@@ -11,6 +14,14 @@ def generate_launch_description():
     # Déclaration du répertoire de lancement de curobo_ros
     curobo_ros_launch_dir = os.path.join(
         get_package_share_directory('curobo_ros'), 'launch')
+
+    trajectory_preview_launch_dir = os.path.join(
+        get_package_share_directory('trajectory_preview'), 'launch')
+
+    urdf_file_name = 'm1013.urdf'
+
+    urdf = Command(['cat ', PathJoinSubstitution(
+        [FindPackageShare('curobo_ros'), 'curobo_doosan/src/m1013/', urdf_file_name])])
 
     return LaunchDescription([
         # Define the static transform publisher node
@@ -61,6 +72,18 @@ def generate_launch_description():
             executable='curobo_int_mark',
             name='curobo_int_mark',
             output='screen'
+        ),
+
+        # Include the trajectory_preview launch file
+        IncludeLaunchDescription(
+            XMLLaunchDescriptionSource(
+                os.path.join(trajectory_preview_launch_dir,
+                             'robot_model_preview_pipeline.launch.xml')
+            ),
+            launch_arguments={
+                'robot_description': urdf,
+                'root_frame': 'base_0',
+            }.items(),
         ),
 
         # Log an informational message

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'robot_description': urdf,
-                'root_frame': 'base_0',
+                'root_frame': 'world',
             }.items(),
         ),
 

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -15,9 +15,6 @@ def generate_launch_description():
     curobo_ros_launch_dir = os.path.join(
         get_package_share_directory('curobo_ros'), 'launch')
 
-    trajectory_preview_launch_dir = os.path.join(
-        get_package_share_directory('trajectory_preview'), 'launch')
-
     urdf_file_name = 'm1013.urdf'
 
     urdf = Command(['cat ', PathJoinSubstitution(
@@ -77,7 +74,7 @@ def generate_launch_description():
         # Include the trajectory_preview launch file
         IncludeLaunchDescription(
             XMLLaunchDescriptionSource(
-                os.path.join(trajectory_preview_launch_dir,
+                os.path.join(curobo_ros_launch_dir,
                              'robot_model_preview_pipeline.launch.xml')
             ),
             launch_arguments={

--- a/launch/robot_model_preview_pipeline.launch.xml
+++ b/launch/robot_model_preview_pipeline.launch.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0."?>
+<!-- This launch file comes from the trajectory_preview repository (https://github.com/swri-robotics/trajectory_preview)
+     The "preview_joint_states_topic" arg was changed to its correct topic in order to make the pipeline function -->
+<launch>
+  <arg name="robot_description" description="Robot description string" />
+  <arg name="root_frame" description="Root frame of the nominal TF tree, at which to connect the preview TF tree" />
+  <arg name="preview_joint_states_topic" default="/trajectory/joint_states"/>
+
+  <node pkg="joint_state_publisher" exec="joint_state_publisher" namespace="preview">
+    <param name="source_list" value="[$(var preview_joint_states_topic)]"/>
+  </node>
+
+  <node pkg="robot_state_publisher" exec="robot_state_publisher" namespace="preview">
+    <param name="robot_description" value="$(var robot_description)"/>
+    <param name="frame_prefix" value="preview/"/>
+  </node>
+
+  <node pkg="tf2_ros" exec="static_transform_publisher" args="0 0 0 0 0 0 $(var root_frame) preview/$(var root_frame)" namespace="preview"/>
+
+</launch>

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -321,7 +321,7 @@ Visualization Manager:
       Mass Properties:
         Inertia: false
         Mass: false
-      Name: RobotModel
+      Name: PreviewRobotModel
       TF Prefix: /preview
       Update Interval: 0
       Value: true

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -28,6 +28,9 @@ Panels:
     Name: Time
     SyncMode: 0
     SyncSource: DepthCloud
+  - Class: trajectory_preview/TrajectoryPreviewPanel
+    Name: Trajectory Preview
+    Value: true
 Visualization Manager:
   Class: ""
   Displays:
@@ -90,18 +93,15 @@ Visualization Manager:
           base_0:
             camera_link:
               camera_color_frame:
-                camera_color_optical_frame:
-                  {}
+                camera_color_optical_frame: {}
               camera_depth_frame:
-                camera_depth_optical_frame:
-                  {}
+                camera_depth_optical_frame: {}
             link1:
               link2:
                 link3:
                   link4:
                     link5:
-                      link6:
-                        {}
+                      link6: {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -181,8 +181,7 @@ Visualization Manager:
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: MarkerArray
-      Namespaces:
-        {}
+      Namespaces: {}
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -232,8 +231,7 @@ Visualization Manager:
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: MarkerArray
-      Namespaces:
-        {}
+      Namespaces: {}
       Topic:
         Depth: 5
         Durability Policy: Volatile

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -261,7 +261,7 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /visualization_marker_voxel
       Value: true
-    - Alpha: 1
+    - Alpha: 0.5
       Class: rviz_default_plugins/RobotModel
       Collision Enabled: false
       Description File: ""

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -7,7 +7,6 @@ Panels:
         - /Global Options1
         - /Status1
         - /DepthCloud1/Auto Size1
-        - /MarkerArray2
       Splitter Ratio: 0.5
     Tree Height: 545
   - Class: rviz_common/Selection
@@ -30,7 +29,6 @@ Panels:
     SyncSource: DepthCloud
   - Class: trajectory_preview/TrajectoryPreviewPanel
     Name: Trajectory Preview
-    Value: true
 Visualization Manager:
   Class: ""
   Displays:
@@ -81,6 +79,22 @@ Visualization Manager:
           Value: true
         link6:
           Value: true
+        preview/base_0:
+          Value: true
+        preview/link1:
+          Value: true
+        preview/link2:
+          Value: true
+        preview/link3:
+          Value: true
+        preview/link4:
+          Value: true
+        preview/link5:
+          Value: true
+        preview/link6:
+          Value: true
+        preview/world:
+          Value: true
         world:
           Value: true
       Marker Scale: 1
@@ -102,6 +116,13 @@ Visualization Manager:
                   link4:
                     link5:
                       link6: {}
+            preview/base_0:
+              preview/link1:
+                preview/link2:
+                  preview/link3:
+                    preview/link4:
+                      preview/link5:
+                        preview/link6: {}
       Update Interval: 0
       Value: true
     - Alpha: 1
@@ -181,7 +202,8 @@ Visualization Manager:
     - Class: rviz_default_plugins/MarkerArray
       Enabled: true
       Name: MarkerArray
-      Namespaces: {}
+      Namespaces:
+        trajectory: true
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -239,6 +261,71 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /visualization_marker_voxel
       Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /preview/robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_0:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        link6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        world:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: /preview
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -317,6 +404,8 @@ Window Geometry:
   Time:
     collapsed: false
   Tool Properties:
+    collapsed: false
+  Trajectory Preview:
     collapsed: false
   Views:
     collapsed: true


### PR DESCRIPTION
First, add [trajectory preview](https://github.com/swri-robotics/trajectory_preview) to the project.
This required:
- Publishing the trajectory from the curobo_test node. Also made it possible to run without a depth input from a camera using a flag.
- Adding a launch file to correct a subscription topic mismatch in the source trajectory preview one.
- Adding the necessary parts to the RViz config file to use the panel and see the second robot model.
- Adding the source repository to the dockerfile.

On the params side, some exploratory ones were first added to control the trajectory generation configuration and the generated voxel sizes.

Everything was thoroughly tested after merging with `main`, except changing the `voxel_size` while the program is running with a depth camera. This will be done shortly, and corrected if need be.  
