### PR TITLE
Add trajectory parameters, world config service and entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ ros2 run curobo_ros curobo_gen_traj
 Pour utiliser Rviz2 afin de visualiser le robot ou toute autre chose, veuillez exécuter la commande suivante :
 
 ```bash
-ros2 launch curobo_ros launch_rviz2.launch.py
+ros2 launch curobo_ros gen_traj.launch.py
 ```
 
 Ce fichier de lancement est configurable a votre souhait.

--- a/README.md
+++ b/README.md
@@ -133,3 +133,24 @@ sudo apt-get update && sudo apt-get install --reinstall -y \
   libmpich-dev \
   hwloc-nox libmpich12 mpich
 ```
+
+### Problèmes exclusifs à Windows
+
+#### Incapacité de lancer les conteneurs
+
+Dépendamment de la configuration du matériel, Docker pourrait ne pas fonctionner du tout dû à une absence de mémoire virtuelle. Pour régler cela, il suffit d'activer l'option de `virtualisation` du CPU dans votre BIOS. Le nom exacte de l'option et la méthode pour effectuer le changement variera d'un ordinateur à l'autre.
+
+#### Incapacité de lancer de fenêtres à partir du Docker sur Windows
+
+Le projet nécessite un `Xserver` pour lancer des fenêtres à partir du Docker sur l'ordinateur local. Une solution sous Windows est l'utilisation de [XLaunch](https://x.cygwin.com/docs/xlaunch/) disponible [ici](https://sourceforge.net/projects/vcxsrv/).
+
+Préalablement au lancement initial du script `start_docker_x86.sh`, il faut:
+
+- Lancer XLaunch. Choissisez les options par défaut, sauf pour la case `Disable access control` qu'il faut cocher.
+- Dans le terminal que vous utiliserez pour lancer le script, effectuez:
+
+  ```bash
+  export DISPLAY=<adresse_IP>:0
+  ```
+
+  Votre adresse IP locale peut être trouvé grâce à la commande `ipconfig`

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -36,9 +36,6 @@ class CuRoboTrajectoryMaker(Node):
         self.declare_parameter('timeout', 5.0)
         self.declare_parameter('time_dilation_factor', 0.5)
 
-        initial_voxel_size = 0.02
-        self.declare_parameter('voxel_size', initial_voxel_size)
-
         self.default_config = None
         self.j_names = None
         self.robot_cfg = None
@@ -47,6 +44,7 @@ class CuRoboTrajectoryMaker(Node):
         self.depth_image = None
         self.marker_data = None
         self.depth = 0
+        self.voxel_size = 0.02
 
         self.marker_publisher = MarkerPublisher()
         self.trajectory_publisher = self.create_publisher(
@@ -66,7 +64,7 @@ class CuRoboTrajectoryMaker(Node):
                     "world": {
                         "pose": [0, 0, 0, 1, 0, 0, 0],
                         "integrator_type": "occupancy",
-                        "voxel_size":  initial_voxel_size,
+                        "voxel_size":  self.voxel_size,
                     },
                 },
             }
@@ -240,15 +238,12 @@ class CuRoboTrajectoryMaker(Node):
         # Voxel debug
         bounding = Cuboid("t", dims=[1, 1, 1.0], pose=[1, 0, 0.5, 1, 0, 0, 0])
 
-        voxel_size = self.get_parameter(
-            'voxel_size').get_parameter_value().double_value
-
         voxels = self.world_model.get_voxels_in_bounding_box(
-            bounding, voxel_size)
+            bounding, self.voxel_size)
         # print(len(voxels))
         if voxels.shape[0] > 0:
             voxels = voxels.cpu().numpy()
-        self.marker_publisher.publish_markers_voxel(voxels, voxel_size)
+        self.marker_publisher.publish_markers_voxel(voxels, self.voxel_size)
 
     def trajectory_generator(self):
         if not self.marker_received:

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -118,7 +118,7 @@ class CuRoboTrajectoryMaker(Node):
 
         #### CAMERA INFO ####
         self.success, camera_info_sub = wait_for_message(
-            CameraInfo, self, '/camera/camera/depth/camera_info', 10)
+            CameraInfo, self, '/camera/camera/depth/camera_info', 1)
         if self.success:
             self.intrinsics = torch.tensor(
                 camera_info_sub.k).view(3, 3).float()

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -208,11 +208,8 @@ class CuRoboTrajectoryMaker(Node):
         # Set joint names
         joint_trajectory_msg.joint_names = traj.joint_names
 
-        # Determine the number of points (assuming position list defines this)
-        num_points = len(traj.position)
-
-        # Create a list of JointTrajectoryPoints
-        for i in range(num_points):
+        # Create a list of JointTrajectoryPoints for every position in the JointState
+        for i in range(len(traj.position)):
             joint_trajectory_point = JointTrajectoryPoint()
 
             # Extract the i-th positions, velocities, and accelerations

--- a/docker/start_docker_x86.sh
+++ b/docker/start_docker_x86.sh
@@ -10,19 +10,35 @@
 ## its affiliates is strictly prohibited.
 ##
 
-# Assurez-vous que le serveur X11 autorise les connexions depuis Docker
-xhost +local:docker
+if ! [[ "$OSTYPE" == "msys" ]]; then
+    # Assurez-vous que le serveur X11 autorise les connexions depuis Docker
+    xhost +local:docker
 
-# Exécutez le conteneur Docker avec les bonnes options
-docker run --name x86docker --rm -it \
-    --privileged \
-    -e NVIDIA_DISABLE_REQUIRE=1 \
-    -e NVIDIA_DRIVER_CAPABILITIES=all \
-    --device=/dev/:/dev/ \
-    --hostname ros1-docker \
-    --add-host ros1-docker:127.0.0.1 \
-    --gpus all \
-    --network host \
-    -e DISPLAY=$DISPLAY \
-    -v /tmp/.X11-unix:/tmp/.X11-unix \
-    curobo_docker:x86
+    # Exécutez le conteneur Docker avec les bonnes options
+    docker run --name x86docker --rm -it \
+        --privileged \
+        -e NVIDIA_DISABLE_REQUIRE=1 \
+        -e NVIDIA_DRIVER_CAPABILITIES=all \
+        --device=/dev/:/dev/ \
+        --hostname ros1-docker \
+        --add-host ros1-docker:127.0.0.1 \
+        --gpus all \
+        --network host \
+        -e DISPLAY=$DISPLAY \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        curobo_docker:x86
+else
+    echo "Detected OS is msys, make sure to have an X server running on your host machine"
+    # Exécutez seulement le conteneur Docker avec les options appropriées
+    docker run --name x86docker --rm -it \
+        --privileged \
+        -e NVIDIA_DISABLE_REQUIRE=1 \
+        -e NVIDIA_DRIVER_CAPABILITIES=all \
+        --hostname ros1-docker \
+        --add-host ros1-docker:127.0.0.1 \
+        --gpus all \
+        --network host \
+        -e DISPLAY=$DISPLAY \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        curobo_docker:x86
+fi

--- a/docker/x86.dockerfile
+++ b/docker/x86.dockerfile
@@ -140,12 +140,6 @@ RUN python -m pip install "robometrics[evaluator] @ git+https://github.com/fishb
 
 RUN export LD_LIBRARY_PATH="/opt/hpcx/ucx/lib:$LD_LIBRARY_PATH"
 
-ADD https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64 /tmp/code_latest_amd64.deb
-RUN sudo dpkg -i /tmp/code_latest_amd64.deb
-
-#alias for code:
-
-RUN echo "alias code='code --user-data-dir=./vscode --no-sandbox'" >> /root/.bashrc
 ADD http://archive.ubuntu.com/ubuntu/pool/main/libu/libusb-1.0/libusb-1.0-0_1.0.25-1ubuntu2_amd64.deb /tmp/libusb-1.0-0_1.0.25-1ubuntu2_amd64.deb
 RUN dpkg -i /tmp/libusb-1.0-0_1.0.25-1ubuntu2_amd64.deb
 

--- a/launch/gen_traj.launch.py
+++ b/launch/gen_traj.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'robot_description': urdf,
-                'root_frame': 'base_0',
+                'root_frame': 'world',
             }.items(),
         ),
 

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -321,7 +321,7 @@ Visualization Manager:
       Mass Properties:
         Inertia: false
         Mass: false
-      Name: RobotModel
+      Name: PreviewRobotModel
       TF Prefix: /preview
       Update Interval: 0
       Value: true

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -261,7 +261,7 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /visualization_marker_voxel
       Value: true
-    - Alpha: 1
+    - Alpha: 0.5
       Class: rviz_default_plugins/RobotModel
       Collision Enabled: false
       Description File: ""


### PR DESCRIPTION
In this pull request, I added:

- Trajectory parameters for `voxel_size` and `collision_activation_distance`.
- These are used in the `update_motion_gen_config` service that redoes the necessary parts of the warm-up sequence.
- An entrypoint script to both checkout and build the desired branch and install the dependencies to fix the `ucm_set_global_opts` bug.
