### PR TITLE
Base setup for adding objects

### DIFF
--- a/curobo_ros/core/config_wrapper.py
+++ b/curobo_ros/core/config_wrapper.py
@@ -1,0 +1,114 @@
+import os
+
+# TODO: Remove unused imports
+from curobo_msgs.srv import AddObject
+from curobo.geom.sdf.world import CollisionCheckerType
+from curobo.geom.types import Cuboid, WorldConfig
+from curobo.types.base import TensorDeviceType
+from curobo.types.camera import CameraObservation
+from curobo.types.math import Pose
+from curobo.types.robot import JointState
+from curobo.util_file import load_yaml, join_path, get_world_configs_path
+from curobo.wrap.reacher.motion_gen import MotionGen, MotionGenConfig, MotionGenPlanConfig
+
+from ament_index_python.packages import get_package_share_directory
+
+
+class ConfigWrapper:
+    '''
+    This class is used to wrap the configuration of the robot and the world for the trajectory generation class.
+    It removes responsibilities relative to motion generation configuration from the main node.
+    The original class uses the "Visitor" pattern to access these functionalities without splitting ownership of the node.
+    '''
+
+    def __init__(self):
+        # Motion generation parameters
+        self.trajopt_tsteps = 32
+        self.collision_checker_type = CollisionCheckerType.BLOX
+        self.use_cuda_graph = True
+        self.num_trajopt_seeds = 12
+        self.num_graph_seeds = 12
+        self.interpolation_dt = 0.03
+        self.acceleration_scale = 1.0
+        self.self_collision_check = True
+        self.maximum_trajectory_dt = 0.25
+        self.finetune_dt_scale = 1.05
+        self.fixed_iters_trajopt = True
+        self.finetune_trajopt_iters = 300
+        self.minimize_jerk = True
+
+        # World config parameters
+        self.world_cfg = None
+        self.world_pose = [0, 0, 0, 1, 0, 0, 0]
+        self.world_integrator_type = "occupancy"
+
+        # Load robot configuration and other configuration files
+        config_file_path = os.path.join(get_package_share_directory(
+            "curobo_ros"), 'curobo_doosan/src/m1013/m1013.yml')
+        self.robot_cfg = load_yaml(config_file_path)["robot_cfg"]
+
+        self.j_names = self.robot_cfg["kinematics"]["cspace"]["joint_names"]
+        self.default_config = self.robot_cfg["kinematics"]["cspace"]["retract_config"]
+
+        self.world_cfg_table = WorldConfig.from_dict(
+            load_yaml(join_path(get_world_configs_path(), "collision_wall.yml")))
+
+    def set_motion_gen_config(self, node, request, response):
+        self.world_cfg = WorldConfig.from_dict(
+            {
+                "blox": {
+                    "world": {
+                        "pose": self.world_pose,
+                        "integrator_type": self.world_integrator_type,
+                        "voxel_size":  node.get_parameter('voxel_size').get_parameter_value().double_value,
+                    },
+                },
+            }
+        )
+
+        # TODO: Use the service to add objects instead
+        self.world_cfg_table.cuboid[0].pose[2] -= 0.01
+        self.world_cfg.add_obstacle(self.world_cfg_table.cuboid[0])
+        self.world_cfg.add_obstacle(self.world_cfg_table.cuboid[1])
+
+        motion_gen_config = MotionGenConfig.load_from_robot_config(
+            self.robot_cfg,
+            self.world_cfg,
+            node.tensor_args,
+            trajopt_tsteps=self.trajopt_tsteps,
+            collision_checker_type=self.collision_checker_type,
+            use_cuda_graph=self.use_cuda_graph,
+            num_trajopt_seeds=self.num_trajopt_seeds,
+            num_graph_seeds=self.num_graph_seeds,
+            interpolation_dt=self.interpolation_dt,
+            collision_activation_distance=node.get_parameter(
+                'collision_activation_distance').get_parameter_value().double_value,
+            acceleration_scale=self.acceleration_scale,
+            self_collision_check=self.self_collision_check,
+            maximum_trajectory_dt=self.maximum_trajectory_dt,
+            finetune_dt_scale=self.finetune_dt_scale,
+            fixed_iters_trajopt=self.fixed_iters_trajopt,
+            finetune_trajopt_iters=self.finetune_trajopt_iters,
+            minimize_jerk=self.minimize_jerk,
+        )
+
+        node.motion_gen = MotionGen(motion_gen_config)
+
+        node.get_logger().info("warming up..")
+
+        node.motion_gen.warmup()
+
+        node.world_model = node.motion_gen.world_collision
+
+        node.get_logger().info("Motion generation config set")
+
+        if response is not None:
+            response.success = True
+            response.message = "Motion generation config set"
+
+        return response
+
+    def callback_add_object(self, node, request, response):
+        print(f"Adding object from {node.get_name()}")
+        response.success = True
+        return response

--- a/curobo_ros/core/config_wrapper.py
+++ b/curobo_ros/core/config_wrapper.py
@@ -1,15 +1,11 @@
 import os
 
-# TODO: Remove unused imports
 from curobo_msgs.srv import AddObject
+
 from curobo.geom.sdf.world import CollisionCheckerType
-from curobo.geom.types import Cuboid, WorldConfig
-from curobo.types.base import TensorDeviceType
-from curobo.types.camera import CameraObservation
-from curobo.types.math import Pose
-from curobo.types.robot import JointState
+from curobo.geom.types import WorldConfig
 from curobo.util_file import load_yaml, join_path, get_world_configs_path
-from curobo.wrap.reacher.motion_gen import MotionGen, MotionGenConfig, MotionGenPlanConfig
+from curobo.wrap.reacher.motion_gen import MotionGen, MotionGenConfig
 
 from ament_index_python.packages import get_package_share_directory
 

--- a/curobo_ros/core/config_wrapper.py
+++ b/curobo_ros/core/config_wrapper.py
@@ -121,7 +121,7 @@ class ConfigWrapper:
         The object is then added to the world configuration.
         '''
         node.get_logger().info(
-            f"Adding object {request.type} from {node.get_name()}")
+            f"Adding object {request.name} for {node.get_name()}")
 
         response.success = True
         obstacle = None
@@ -136,7 +136,7 @@ class ConfigWrapper:
 
         # TODO add more shapes
         match request.type:
-            case "cuboid":
+            case request.CUBOID:
                 obstacle = Cuboid(
                     name=request.name,
                     pose=extracted_pose,

--- a/curobo_ros/core/fk.py
+++ b/curobo_ros/core/fk.py
@@ -11,7 +11,7 @@ from ament_index_python.packages import get_package_share_directory
 import torch
 
 # msg ik
-from capacinet_msg.srv import Fk
+from curobo_msgs.srv import Fk
 from geometry_msgs.msg import Pose
 
 # cuRobo
@@ -19,6 +19,7 @@ from curobo.cuda_robot_model.cuda_robot_model import CudaRobotModel, CudaRobotMo
 from curobo.types.base import TensorDeviceType
 from curobo.types.robot import RobotConfig
 from curobo.util_file import get_robot_configs_path, join_path, load_yaml
+
 
 class FK(Node):
     def __init__(self):
@@ -29,20 +30,24 @@ class FK(Node):
         self.robot_name = "ur10e"
 
         # service for list of poses to calculate the inverse kinematics
-        self.srv_ik = self.create_service(Fk, '/curobo/fk_poses', self.fk_callback)
+        self.srv_ik = self.create_service(
+            Fk, '/curobo/fk_poses', self.fk_callback)
 
         # curobo args
         self.tensor_args = TensorDeviceType()
-        config_file_path = os.path.join(get_package_share_directory("curobo_ros"), 'curobo_doosan/src/m1013/m1013.yml')
+        config_file_path = os.path.join(get_package_share_directory(
+            "curobo_ros"), 'curobo_doosan/src/m1013/m1013.yml')
 
-        config_file = load_yaml(join_path(get_robot_configs_path(), config_file_path))
+        config_file = load_yaml(
+            join_path(get_robot_configs_path(), config_file_path))
         urdf_file = config_file["robot_cfg"]["kinematics"][
             "urdf_path"
         ]  # Send global path starting with "/"
         base_link = config_file["robot_cfg"]["kinematics"]["base_link"]
         ee_link = config_file["robot_cfg"]["kinematics"]["ee_link"]
         # Generate robot configuration from  urdf path, base frame, end effector frame
-        robot_cfg = RobotConfig.from_basic(urdf_file, base_link, ee_link, self.tensor_args)
+        robot_cfg = RobotConfig.from_basic(
+            urdf_file, base_link, ee_link, self.tensor_args)
 
         self.kin_model = CudaRobotModel(robot_cfg.kinematics)
 
@@ -79,10 +84,9 @@ class FK(Node):
 
     def fk_init(self):
         # init the kin model, the firt time it takes a while
-        q = torch.rand((10, self.kin_model.get_dof()), **(self.tensor_args.as_torch_dict()))
+        q = torch.rand((10, self.kin_model.get_dof()), **
+                       (self.tensor_args.as_torch_dict()))
         out = self.kin_model.get_state(q)
-       
-
 
 
 def main(args=None):
@@ -94,5 +98,3 @@ def main(args=None):
 
     fk.destroy_node()
     rclpy.shutdown()
-
-

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -8,12 +8,16 @@ from cv_bridge import CvBridge, CvBridgeError
 import rclpy
 from rclpy.node import Node
 from .wait_for_message import wait_for_message
+
 from builtin_interfaces.msg import Duration
 from geometry_msgs.msg import PoseStamped
 from sensor_msgs.msg import JointState as SensorJointState
 from sensor_msgs.msg import Image, CameraInfo
-from std_srvs.srv import Trigger
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+from capacinet_msg.srv import Fk
+from std_srvs.srv import Trigger
+from curobo_ros_msg.srv import AddObject
 
 from curobo.geom.sdf.world import CollisionCheckerType
 from curobo.geom.types import Cuboid, WorldConfig
@@ -24,7 +28,6 @@ from curobo.types.robot import JointState
 from curobo.util_file import load_yaml, join_path, get_world_configs_path
 from curobo.wrap.reacher.motion_gen import MotionGen, MotionGenConfig, MotionGenPlanConfig
 from .marker_publisher import MarkerPublisher
-from capacinet_msg.srv import Fk
 
 from ament_index_python.packages import get_package_share_directory
 
@@ -58,6 +61,9 @@ class CuRoboTrajectoryMaker(Node):
 
         self.motion_gen_srv = self.create_service(
             Trigger, node_name + '/update_motion_gen_config', self.set_motion_gen_config)
+
+        self.add_object_srv = self.create_service(
+            AddObject, node_name + '/add_object', self.callback_add_object)
 
         # checker
         self.depth_image_received = False
@@ -336,6 +342,11 @@ class CuRoboTrajectoryMaker(Node):
         self.future = self.client.call_async(self.req)
         self.future.add_done_callback(self.callback)
         self.marker_received = False
+
+    def callback_add_object(self, request, response):
+        self.get_logger().info(f"Adding object {request}")
+        response.success = True
+        return response
 
 
 def main(args=None):

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -15,9 +15,8 @@ from sensor_msgs.msg import JointState as SensorJointState
 from sensor_msgs.msg import Image, CameraInfo
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 
-from capacinet_msg.srv import Fk
 from std_srvs.srv import Trigger
-from curobo_ros_msg.srv import AddObject
+from curobo_msgs.srv import AddObject, Fk
 
 from curobo.geom.sdf.world import CollisionCheckerType
 from curobo.geom.types import Cuboid, WorldConfig

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -45,14 +45,10 @@ class CuRoboTrajectoryMaker(Node):
         self.declare_parameter('voxel_size', 0.02)
         self.declare_parameter('collision_activation_distance', 0.025)
 
-        self.default_config = None
-        self.j_names = None
         self.robot_cfg = None
         self.intrinsics = None
-        self.cv_image = None
         self.depth_image = None
         self.marker_data = None
-        self.depth = 0
 
         self.marker_publisher = MarkerPublisher()
         self.trajectory_publisher = self.create_publisher(
@@ -65,7 +61,6 @@ class CuRoboTrajectoryMaker(Node):
             AddObject, node_name + '/add_object', self.callback_add_object)
 
         # checker
-        self.depth_image_received = False
         self.marker_received = False
 
         self.bridge = CvBridge()
@@ -136,8 +131,6 @@ class CuRoboTrajectoryMaker(Node):
         config_file_path = os.path.join(get_package_share_directory(
             "curobo_ros"), 'curobo_doosan/src/m1013/m1013.yml')
         self.robot_cfg = load_yaml(config_file_path)["robot_cfg"]
-        self.j_names = self.robot_cfg["kinematics"]["cspace"]["joint_names"]
-        self.default_config = self.robot_cfg["kinematics"]["cspace"]["retract_config"]
 
         self.world_cfg_table = WorldConfig.from_dict(
             load_yaml(join_path(get_world_configs_path(), "collision_wall.yml")))

--- a/curobo_ros/core/ik.py
+++ b/curobo_ros/core/ik.py
@@ -20,14 +20,14 @@ from curobo.wrap.reacher.ik_solver import IKSolver, IKSolverConfig
 from curobo.geom.types import WorldConfig
 from curobo.geom.sdf.world import CollisionCheckerType
 # msg ik
-from capacinet_msg.srv import Ik
+from curobo_msgs.srv import Ik
 # from data_generation.srv import Collisions
 
 
 # This class use curobo to generate the inverse kinematics of the robot
 
 class IK(Node):
-    
+
     def __init__(self):
         super().__init__('IK')
         # sub with the name string of the robot
@@ -36,7 +36,8 @@ class IK(Node):
         self.robot_name = "ur10e"
 
         # service for list of poses to calculate the inverse kinematics
-        self.srv_ik = self.create_service(Ik, '/curobo/ik_poses', self.ik_callback)
+        self.srv_ik = self.create_service(
+            Ik, '/curobo/ik_poses', self.ik_callback)
         # self.srv_collision = self.create_service(, '/curobo/collision', self.add_collisions)
         # curobo args
         self.tensor_args = TensorDeviceType()
@@ -46,12 +47,14 @@ class IK(Node):
         # base_link = config_file["robot_cfg"]["kinematics"]["base_link"]
         # ee_link = config_file["robot_cfg"]["kinematics"]["ee_link"]
 
-        self.robot_cfg = RobotConfig.from_dict(load_yaml(join_path(get_robot_configs_path(), config_file))["robot_cfg"])
+        self.robot_cfg = RobotConfig.from_dict(
+            load_yaml(join_path(get_robot_configs_path(), config_file))["robot_cfg"])
 
         # collision
         world_file = "collision_cage.yml"
 
-        self.world_cfg = WorldConfig.from_dict(load_yaml(join_path(get_world_configs_path(), world_file)))
+        self.world_cfg = WorldConfig.from_dict(
+            load_yaml(join_path(get_world_configs_path(), world_file)))
 
         # self.world_cfg = WorldConfig(cuboid=world_cfg_table.cuboid, mesh=world_cfg1.mesh)
 
@@ -98,8 +101,10 @@ class IK(Node):
         positions = []
         orientations = []
         for pose in poses:
-            positions.append([pose.position.x, pose.position.y, pose.position.z])
-            orientations.append([pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w])
+            positions.append(
+                [pose.position.x, pose.position.y, pose.position.z])
+            orientations.append(
+                [pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w])
 
         # Convert lists to tensors
         position_tensor = torch.tensor(positions)
@@ -130,7 +135,7 @@ class IK(Node):
 
         # response.joint_angles = result.joint_angles.cpu().numpy().tolist()
         return response
-        
+
     def ik_init(self):
         q_sample = self.ik_solver.sample_configs(self.size_init)
         print(q_sample)
@@ -149,7 +154,6 @@ class IK(Node):
         # print the nb of solutions
         # print(join_results)
         print("Init done")
-
 
     def add_collisions(self):
         return True

--- a/docker/x86.dockerfile
+++ b/docker/x86.dockerfile
@@ -198,11 +198,12 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /home/ros2_ws/src
 ARG CACHE_BUST
 RUN git clone https://github.com/Lab-CORO/CapacitiNet_msg.git && \
+    git clone https://github.com/Lab-CORO/curobo_ros_msg.git && \
     git clone --recurse-submodules https://github.com/Lab-CORO/curobo_ros.git && \
     git clone https://github.com/IntelRealSense/realsense-ros.git -b ros2-master
 
 # Construire les packages un par un pour résoudre les dépendances
-RUN /bin/bash -c "source /opt/ros/humble/setup.bash && cd /home/ros2_ws && colcon build --packages-select capacinet_msg"
+RUN /bin/bash -c "source /opt/ros/humble/setup.bash && cd /home/ros2_ws && colcon build --packages-select capacinet_msg curobo_ros_msg"
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && cd /home/ros2_ws && colcon build"
 RUN echo "source /home/ros2_ws/install/setup.bash" >> ~/.bashrc
 

--- a/docker/x86.dockerfile
+++ b/docker/x86.dockerfile
@@ -197,13 +197,12 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /home/ros2_ws/src
 ARG CACHE_BUST
-RUN git clone https://github.com/Lab-CORO/CapacitiNet_msg.git && \
-    git clone https://github.com/Lab-CORO/curobo_ros_msg.git && \
+RUN git clone https://github.com/Lab-CORO/curobo_msgs.git && \
     git clone --recurse-submodules https://github.com/Lab-CORO/curobo_ros.git && \
     git clone https://github.com/IntelRealSense/realsense-ros.git -b ros2-master
 
 # Construire les packages un par un pour résoudre les dépendances
-RUN /bin/bash -c "source /opt/ros/humble/setup.bash && cd /home/ros2_ws && colcon build --packages-select capacinet_msg curobo_ros_msg"
+RUN /bin/bash -c "source /opt/ros/humble/setup.bash && cd /home/ros2_ws && colcon build --packages-select curobo_msgs"
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && cd /home/ros2_ws && colcon build"
 RUN echo "source /home/ros2_ws/install/setup.bash" >> ~/.bashrc
 

--- a/docker/x86.dockerfile
+++ b/docker/x86.dockerfile
@@ -212,6 +212,9 @@ RUN sudo rosdep init # "sudo rosdep init --include-eol-distros" && \
 
 # Setup for trajectory_preview
 RUN git clone https://github.com/swri-robotics/trajectory_preview.git
+
+# Setup for curobo_rviz
+RUN git clone https://github.com/Lab-CORO/curobo_rviz.git
 WORKDIR /home/ros2_ws
 RUN /bin/bash -c "source /opt/ros/humble/setup.bash && \
     colcon build"

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
   <exec_depend>std_msgs</exec_depend>
 
   <depend>geometry_msgs</depend>
-  <depend>curobo_ros_msg</depend>
+  <depend>curobo_msgs</depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>std_msgs</exec_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>curobo_ros_msg</depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -8,7 +8,7 @@ Panels:
         - /Status1
         - /DepthCloud1/Auto Size1
       Splitter Ratio: 0.5
-    Tree Height: 545
+    Tree Height: 964
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -29,6 +29,8 @@ Panels:
     SyncSource: DepthCloud
   - Class: trajectory_preview/TrajectoryPreviewPanel
     Name: Trajectory Preview
+  - Class: curobo_rviz/RvizArgsPanel
+    Name: RvizArgsPanel
 Visualization Manager:
   Class: ""
   Displays:

--- a/tests/test_fk.py
+++ b/tests/test_fk.py
@@ -1,11 +1,11 @@
-#create a test to send a joint_state msg to the fk service and get the ee position and orientation
+# create a test to send a joint_state msg to the fk service and get the ee position and orientation
 # ceci n'est pas un test a proprment parle
 
 import rclpy
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
 from geometry_msgs.msg import Pose
-from capacinet_msg.srv import Fk
+from curobo_msgs.srv import Fk
 
 
 class TestFk(Node):
@@ -18,7 +18,8 @@ class TestFk(Node):
         self.req.joint_states = []
         self.req.joint_states.append(JointState())
         self.req.joint_states[0].position = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-        self.req.joint_states[0].name = ['joint1', 'joint2', 'joint3', 'joint4', 'joint5', 'joint6']
+        self.req.joint_states[0].name = [
+            'joint1', 'joint2', 'joint3', 'joint4', 'joint5', 'joint6']
         self.future = self.client.call_async(self.req)
         self.future.add_done_callback(self.callback)
 
@@ -28,6 +29,7 @@ class TestFk(Node):
         self.get_logger().info('Result %s' % response.poses[0].orientation)
         # assert the existanc eof a result
         assert response.poses[0].position
+
 
 def main(args=None):
     rclpy.init(args=args)


### PR DESCRIPTION
In this PR:

- `Capacinet_msgs` was changed to `curobo_msgs`.
- Configuration responsibilities related to the cuRobo world and motion generation were transferred to `config_wrapper.py` where possible. The visitor design pattern was used to keep dependency as low as possible without needing a new node.
- The first version of the service to add objects was added. More testing needed to see its impact on trajectory generation. That will be made easier when the `curobo_rviz` task of making the objects visible will be completed.
- Unused class parameters and includes were removed from `generate_trajectory.py`.
- Add `curobo_rviz` to the project.