### PR TITLE
Upgrade object manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Présentement, il est possible d'ajouter ces types:
 - Sphère
 - Capsule
 - Cylindre
-- Mesh à partir d'un fichier fournis par le paramètre optionnel `mesh_file_path` (en développement)
+- Mesh à partir d'un fichier fournis par le paramètre optionnel `mesh_file_path`
 
 Voici un exemple pour l'ajout et le retrait d'un cube de 25 cm:
 
@@ -128,6 +128,12 @@ Retrait:
 
 ```bash
 ros2 service call /curobo_gen_traj/remove_object curobo_msgs/srv/RemoveObject "{name: 'test_cuboid'}"
+```
+
+Il est aussi possible de retirer tous les objets ajoutés d'un seul coup:
+
+```bash
+ros2 service call /curobo_gen_traj/remove_all_objects std_srvs/srv/Trigger
 ```
 
 ## Potentiels problèmes rencontrés

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Remplacer ces champs par ce qui vous convient.
 
 ### Gestion manuelle d'objets virtuels
 
-Des services ont été ajoutés pour ajouter et retirer différents types d'objets à l'environnement.
+Des services ont été ajoutés pour ajouter et retirer différents types d'objets à l'environnement. Il est à noté que, dans tous les cas, les objets sont transformés en Cuboid avant d'être ajoutés au système. Ceci est dû à une limitation actuelle du [Collision World Representation](https://curobo.org/get_started/2c_world_collision.html).
 
 Présentement, il est possible d'ajouter ces types:
 
@@ -134,6 +134,12 @@ Il est aussi possible de retirer tous les objets ajoutés d'un seul coup:
 
 ```bash
 ros2 service call /curobo_gen_traj/remove_all_objects std_srvs/srv/Trigger
+```
+
+Ajout dans le cas d'un mesh:
+
+```bash
+ros2 service call /curobo_gen_traj/add_object curobo_msgs/srv/AddObject "{type: 4, name: 'test_mesh', mesh_file_path: '/home/ros2_ws/src/curobo_ros/curobo_doosan/src/m1013/meshes/m1013_white/MF1013_0_0.dae', pose: {position: {x: 0.40, y: 0.0, z: 1.0}, orientation: {x: 1.0, y: 0.0, z: 0.0, w: 1.0}}, dimensions: {x: 0.0025, y: 0.0025, z: 0.0025}, color: {r: 1.0, g: 0.0, b: 0.0, a: 1.0}}"
 ```
 
 ## Potentiels problèmes rencontrés

--- a/README.md
+++ b/README.md
@@ -104,6 +104,32 @@ ros2 run tf2_ros static_transform_publisher  0.5 0 0.5 0 0 0  base_0 camera_link
 
 Remplacer ces champs par ce qui vous convient.
 
+### Gestion manuelle d'objets virtuels
+
+Des services ont été ajoutés pour ajouter et retirer différents types d'objets à l'environnement.
+
+Présentement, il est possible d'ajouter ces types:
+
+- Cube (Cuboid selon l'appellation cuRobo)
+- Sphère
+- Capsule
+- Cylindre
+- Mesh à partir d'un fichier fournis par le paramètre optionnel `mesh_file_path` (en développement)
+
+Voici un exemple pour l'ajout et le retrait d'un cube de 25 cm:
+
+Ajout:
+
+```bash
+ros2 service call /curobo_gen_traj/add_object curobo_msgs/srv/AddObject "{type: 0, name: 'test_cuboid', pose: {position: {x: 0.70, y: 0.0, z: 1.0}, orientation: {x: 1.0, y: 0.0, z: 0.0, w: 1.0}}, dimensions: {x: 0.25, y: 0.25, z: 0.25}, color: {r: 1.0, g: 0.0, b: 0.0, a: 1.0}}"
+```
+
+Retrait:
+
+```bash
+ros2 service call /curobo_gen_traj/remove_object curobo_msgs/srv/RemoveObject "{name: 'test_cuboid'}"
+```
+
 ## Potentiels problèmes rencontrés
 
 ### Problème potentiel avec CUDA

--- a/curobo_ros/core/config_wrapper.py
+++ b/curobo_ros/core/config_wrapper.py
@@ -164,6 +164,7 @@ class ConfigWrapper:
         # CAPSULE: [radius, _, _]
         # CYLINDER: [radius, height, _]
         # SPHERE: [radius, _, _]
+        # MESH: [scale_x, scale_y, scale_z]
         extracted_dimensions = [request.dimensions.x,
                                 request.dimensions.y, request.dimensions.z]
 
@@ -219,7 +220,7 @@ class ConfigWrapper:
                     pose=extracted_pose,
                     file_path=request.mesh_file_path,
                     scale=extracted_dimensions
-                )
+                ).get_cuboid()
 
             case _:  # default
                 response.success = False

--- a/curobo_ros/core/config_wrapper.py
+++ b/curobo_ros/core/config_wrapper.py
@@ -231,6 +231,7 @@ class ConfigWrapper:
             self.world_cfg.add_obstacle(obstacle)
             self.update_world_config(node)
             response.message = 'Object ' + request.name + ' added successfully'
+            node.get_logger().info(f"Successfully added {request.name}")
 
         return response
 
@@ -267,6 +268,8 @@ class ConfigWrapper:
 
         response.success = True
         response.message = 'Object ' + request.name + ' removed successfully'
+        node.get_logger().info(
+            f"Removed object {request.name} for {node.get_name()}")
         return response
 
     def callback_remove_all_objects(self, node, _, response):
@@ -287,4 +290,5 @@ class ConfigWrapper:
 
         response.success = True
         response.message = 'All objects removed successfully'
+        node.get_logger().info(f"All objects removed for {node.get_name()}")
         return response

--- a/curobo_ros/core/config_wrapper.py
+++ b/curobo_ros/core/config_wrapper.py
@@ -3,7 +3,7 @@ import os
 from curobo_msgs.srv import AddObject, RemoveObject
 
 from curobo.geom.sdf.world import CollisionCheckerType
-from curobo.geom.types import WorldConfig, Cuboid, Capsule, Cylinder, Sphere
+from curobo.geom.types import WorldConfig, Cuboid, Capsule, Cylinder, Sphere, Mesh
 from curobo.util_file import load_yaml, join_path, get_world_configs_path
 from curobo.wrap.reacher.motion_gen import MotionGen, MotionGenConfig
 
@@ -212,6 +212,14 @@ class ConfigWrapper:
                     radius=extracted_dimensions[0],
                     color=extracted_color,
                 ).get_cuboid()
+
+            case request.MESH:
+                obstacle = Mesh(
+                    name=request.name,
+                    pose=extracted_pose,
+                    file_path=request.mesh_file_path,
+                    scale=extracted_dimensions
+                )
 
             case _:  # default
                 response.success = False

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -43,7 +43,7 @@ class CuRoboTrajectoryMaker(Node):
         self.declare_parameter('time_dilation_factor', 0.5)
 
         # World configuration parameters
-        self.declare_parameter('voxel_size', 0.08)
+        self.declare_parameter('voxel_size', 0.05)
         self.declare_parameter('collision_activation_distance', 0.025)
 
         # Publishers and subscribers
@@ -62,7 +62,7 @@ class CuRoboTrajectoryMaker(Node):
             AddObject, node_name + '/add_object', partial(self.config_wrapper.callback_add_object, self))
 
         self.add_object_srv = self.create_service(
-            RemoveObject, node_name + '/remove_object', self.config_wrapper.callback_remove_object)
+            RemoveObject, node_name + '/remove_object', partial(self.config_wrapper.callback_remove_object, self))
 
         # Markers
         self.marker_data = None
@@ -191,7 +191,8 @@ class CuRoboTrajectoryMaker(Node):
 
     def debug_voxel(self):
         # Voxel debug
-        bounding = Cuboid("t", dims=[2, 2, 2.0], pose=[0, 0, 0, 1, 0, 0, 0])
+        bounding = Cuboid("t", dims=[2.0, 2.0, 2.0], pose=[
+                          0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0])
 
         voxel_size = self.get_parameter(
             'voxel_size').get_parameter_value().double_value

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -16,7 +16,7 @@ from sensor_msgs.msg import Image, CameraInfo
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 
 from std_srvs.srv import Trigger
-from curobo_msgs.srv import AddObject, Fk
+from curobo_msgs.srv import AddObject, Fk, RemoveObject
 from .config_wrapper import ConfigWrapper
 
 from curobo.geom.types import Cuboid
@@ -60,6 +60,9 @@ class CuRoboTrajectoryMaker(Node):
 
         self.add_object_srv = self.create_service(
             AddObject, node_name + '/add_object', partial(self.config_wrapper.callback_add_object, self))
+
+        self.add_object_srv = self.create_service(
+            RemoveObject, node_name + '/remove_object', self.config_wrapper.callback_remove_object)
 
         # Markers
         self.marker_data = None
@@ -201,7 +204,6 @@ class CuRoboTrajectoryMaker(Node):
         self.marker_publisher.publish_markers_voxel(voxels, voxel_size)
 
     def trajectory_generator(self):
-        self.debug_voxel()
         if not self.marker_received:
             return
         while not self.client.wait_for_service(timeout_sec=1.0):
@@ -210,8 +212,6 @@ class CuRoboTrajectoryMaker(Node):
         self.req = Fk.Request()
         self.req.joint_states = []
 
-        # self.update_camera()
-        # end debug
         self.get_actual_pose()
 
         # get goal pose and generate traj

--- a/curobo_ros/core/generate_trajectory.py
+++ b/curobo_ros/core/generate_trajectory.py
@@ -64,6 +64,9 @@ class CuRoboTrajectoryMaker(Node):
         self.add_object_srv = self.create_service(
             RemoveObject, node_name + '/remove_object', partial(self.config_wrapper.callback_remove_object, self))
 
+        self.remove_all_objects_srv = self.create_service(
+            Trigger, node_name + '/remove_all_objects', partial(self.config_wrapper.callback_remove_all_objects, self))
+
         # Markers
         self.marker_data = None
         self.marker_received = False

--- a/curobo_ros/core/marker_publisher.py
+++ b/curobo_ros/core/marker_publisher.py
@@ -1,14 +1,16 @@
 import rclpy
 from rclpy.node import Node
 from visualization_msgs.msg import Marker, MarkerArray
-from geometry_msgs.msg import Point
+
 
 class MarkerPublisher(Node):
     def __init__(self):
         super().__init__('marker_publisher')
-        self.marker_traj_pub = self.create_publisher(MarkerArray, 'visualization_marker_array', 10)
-        self.marker_voxel_pub = self.create_publisher(MarkerArray, 'visualization_marker_voxel', 10)
-    
+        self.marker_traj_pub = self.create_publisher(
+            MarkerArray, 'visualization_marker_array', 10)
+        self.marker_voxel_pub = self.create_publisher(
+            MarkerArray, 'visualization_marker_voxel', 10)
+
     def delete_marker(self, pub, ns):
         marker_array_msg = MarkerArray()
         marker = Marker()
@@ -20,7 +22,7 @@ class MarkerPublisher(Node):
 
     def publish_markers_trajectory(self, poses):
         marker_array = MarkerArray()
-        
+
         for i, pose in enumerate(poses):
             if i == 0:
                 # Create a red sphere marker for the start position
@@ -79,43 +81,45 @@ class MarkerPublisher(Node):
 
                 marker_array.markers.append(text_marker)
 
-        self.get_logger().info(f'Publishing marker array with {len(marker_array.markers)} markers')
+        self.get_logger().info(
+            f'Publishing marker array with {len(marker_array.markers)} markers')
         self.marker_traj_pub.publish(marker_array)
     """
     poses: [x,y,z voxel_size]
     """
+
     def publish_markers_voxel(self, poses, voxel_size):
-        # self.delete_marker(self.marker_voxel_pub, "voxel")
+        self.delete_marker(self.marker_voxel_pub, "voxel")
         marker_array = MarkerArray()
         for i, pose in enumerate(poses):
-                voxel_marker = Marker()
-                voxel_marker.header.frame_id = "base_0"
-                voxel_marker.header.stamp = self.get_clock().now().to_msg()
-                voxel_marker.ns = "voxel"
-                voxel_marker.id = i
-                voxel_marker.type = Marker.CUBE
-                voxel_marker.action = Marker.ADD
-                # print(type(pose))
-                # print(pose)
-                voxel_marker.scale.x = float(pose[3])
-                voxel_marker.scale.y = float(pose[3])
-                voxel_marker.scale.z = float(pose[3])
-                voxel_marker.color.a = 1.0  # Transparence
-                voxel_marker.color.r = 1.0  # Couleur rouge
-                voxel_marker.color.g = 0.0  # Couleur verte
-                voxel_marker.color.b = 0.0  # Couleur bleue
-                
-                voxel_marker.pose.position.x = float(pose[0])
-                voxel_marker.pose.position.y = float(pose[1])
-                voxel_marker.pose.position.z = float(pose[2])
-                voxel_marker.pose.orientation.x = 0.0
-                voxel_marker.pose.orientation.y = 0.0
-                voxel_marker.pose.orientation.z = 0.0
-                voxel_marker.pose.orientation.w = 1.0
-                
+            voxel_marker = Marker()
+            voxel_marker.header.frame_id = "base_0"
+            voxel_marker.header.stamp = self.get_clock().now().to_msg()
+            voxel_marker.ns = "voxel"
+            voxel_marker.id = i
+            voxel_marker.type = Marker.CUBE
+            voxel_marker.action = Marker.ADD
+            # print(type(pose))
+            # print(pose)
+            voxel_marker.scale.x = float(pose[3])
+            voxel_marker.scale.y = float(pose[3])
+            voxel_marker.scale.z = float(pose[3])
+            voxel_marker.color.a = 1.0  # Transparence
+            voxel_marker.color.r = 1.0  # Couleur rouge
+            voxel_marker.color.g = 0.0  # Couleur verte
+            voxel_marker.color.b = 0.0  # Couleur bleue
 
-                marker_array.markers.append(voxel_marker)
+            voxel_marker.pose.position.x = float(pose[0])
+            voxel_marker.pose.position.y = float(pose[1])
+            voxel_marker.pose.position.z = float(pose[2])
+            voxel_marker.pose.orientation.x = 0.0
+            voxel_marker.pose.orientation.y = 0.0
+            voxel_marker.pose.orientation.z = 0.0
+            voxel_marker.pose.orientation.w = 1.0
+
+            marker_array.markers.append(voxel_marker)
         self.marker_voxel_pub.publish(marker_array)
+
 
 def main(args=None):
     rclpy.init(args=args)
@@ -123,6 +127,7 @@ def main(args=None):
     rclpy.spin(node)
     node.destroy_node()
     rclpy.shutdown()
+
 
 if __name__ == '__main__':
     main()

--- a/rviz/rviz_curobo.rviz
+++ b/rviz/rviz_curobo.rviz
@@ -31,6 +31,8 @@ Panels:
     Name: Trajectory Preview
   - Class: curobo_rviz/RvizArgsPanel
     Name: RvizArgsPanel
+  - Class : add_objects_panel/AddObjectsPanel
+    Name: AddObjectsPanel
 Visualization Manager:
   Class: ""
   Displays:


### PR DESCRIPTION
Object manipulation now includes:

- Removing a single object.
- Removing all objects.
- Adding Mesh type objects (needs a matching version of `curobo_msgs`).
- Checking to confirm the validity of added objects. For example, existing objects or those that would be under the ground are denied.

Other changes:

- README now has a section for object manipulation, with examples.
- The `publish_markers_voxel` function now also deletes old voxels, allowing RViz to stay up to date. The file was also formatted.
- Optimized `world_cfg` management, it is now only created once and then updated continuously.
- The panel for adding objects is in the RViz configuration file.
